### PR TITLE
Apply add mode to add license and copyright

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Here a short summary:
 
 - `report` --- Convert [oss-pkg-info.yaml](https://github.com/fosslight/fosslight_reuse/blob/main/tests/report/oss-pkg-info.yaml) to [FOSSLight-Report.xlsx](https://fosslight.org/fosslight-guide-en/learn/2_fosslight_report.html) and vice versa.
 
+- `add` --- Add copyright and license to missing file(s)
+
 
 ## 👏 How to report issue
 

--- a/src/fosslight_reuse/_add.py
+++ b/src/fosslight_reuse/_add.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 LG Electronics Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+import os
+import re
+import logging
+import fosslight_util.constant as constant
+from yaml import safe_dump
+from fosslight_util.set_log import init_log
+from datetime import datetime
+from ._fosslight_reuse import reuse_for_project, reuse_for_files, print_error
+from reuse.header import run
+from reuse._comment import EXTENSION_COMMENT_STYLE_MAP_LOWERCASE
+from reuse._main import parser as reuse_arg_parser
+
+_PKG_NAME = "fosslight_reuse"
+_auto_add_mode = False
+_result_log = {}
+logger = logging.getLogger(constant.LOGGER_NAME)
+
+
+def check_file_extension(file_list):
+    files_filtered = []
+
+    if file_list != "":
+        for file in file_list:
+            try:
+                file_extension = os.path.splitext(file)[1].lower()
+                if file_extension == "":
+                    logger.warning("Error - can't check file extension : " + file)
+                if file_extension in EXTENSION_COMMENT_STYLE_MAP_LOWERCASE:
+                    files_filtered.append(file)
+            except Exception as ex:
+                logger.warning("Error - Unknown error to check file exteion " + ex)
+
+    return files_filtered
+
+
+def check_license_and_copyright(path_to_find, all_files, missing_license, missing_copyright):
+    # Check file extension for each list
+    all_files_fitered = check_file_extension(all_files)
+    missing_license_filtered = check_file_extension(missing_license)
+    missing_copyright_filtered = check_file_extension(missing_copyright)
+
+    skip_files = sorted(list(set(all_files_fitered) - set(missing_license_filtered) - set(missing_copyright_filtered)))
+    logger.info("# File list that have both license and copyright : {count} / {total}".format(
+            count=len(skip_files),
+            total=len(all_files)))
+
+    for file in skip_files:
+        file_list = list()
+        file_list.append(file)
+
+        unused_lic_list, usused_cop_list, error_occurred, project = reuse_for_files(path_to_find, file_list)
+
+    return missing_license_filtered, missing_copyright_filtered
+
+
+def convert_to_spdx_format(input_string):
+    input_string = input_string.replace(" ", "-")
+    input_converted = "LicenseRef-" + input_string
+    return input_converted
+
+
+def check_input_format(input_copyright):
+    regex = re.compile(r'Copyright(\s)+(\(c\)\s)?\s*\d{4}(-\d{4})*(\s)+(\S)+')
+    check_ok = True
+
+    if regex.match(input_copyright) is None:
+        logger.warning(" You have to input with following format - 'Copyright <year> <name>'")
+        check_ok = False
+
+    return check_ok
+
+
+def set_missing_license_copyright(missing_license_filtered, missing_copyright_filtered, project, path_to_find, license, copyright):
+    input_license = None
+    input_copyright = None
+
+    try:
+        main_parser = reuse_arg_parser()
+    except Exception as ex:
+        print_error('Error_get_arg_parser :' + str(ex))
+
+    # Print missing license
+    if missing_license_filtered is not None and len(missing_license_filtered) > 0:
+        input_str = ""
+        missing_license_list = []
+
+        logger.info("# Missing license File(s) ")
+        for lic_file in sorted(missing_license_filtered):
+            logger.info(f"  * {lic_file}")
+            missing_license_list.append(path_to_find + '/' + lic_file)
+
+        if _auto_add_mode:
+            # Automatic add mode
+            input_license = license
+        else:
+            # Manual add Mode
+            logger.info("# Select a license to write in the license missing files ")
+            select = input("   1.MIT,  2.Apache-2.0,  3.LGE-Proprietary,  4.Manaully Input,  5.Not select now : ")
+            if select == '1' or select == 'MIT':
+                input_license = 'MIT'
+            elif select == '2' or select == 'Apache-2.0':
+                input_license = 'Apache-2.0'
+            elif select == '3' or select == 'LGE Proprietary License':
+                input_license = 'LicenseRef-LGE-Proprietary'
+            elif select == '4' or select == 'Manually Input':
+                input_str = input("   ## Input your License : ")
+                input_license = input_str
+            elif select == '5' or select == 'Quit' or select == 'quit':
+                logger.info(" Not selected any license to write ")
+                return
+
+        if input_license != "":
+            logger.warning(f"  * Your input license : {input_license}")
+            parsed_args = main_parser.parse_args(['addheader', '--license', str(input_license)] + missing_license_list)
+            try:
+                run(parsed_args, project)
+            except Exception as ex:
+                print_error('Error_call_run_in_license :' + str(ex))
+
+    # Print copyright
+    if missing_copyright_filtered is not None and len(missing_copyright_filtered) > 0:
+        missing_copyright_list = []
+
+        logger.info("# Missing Copyright File(s) ")
+        for cop_file in sorted(missing_copyright_filtered):
+            logger.info(f"  * {cop_file}")
+            missing_copyright_list.append(os.getcwd() + '/' + path_to_find + '/' + cop_file)
+
+        if _auto_add_mode:
+            # Automatic add mode
+            input_copyright = copyright
+        else:
+            # Manual add Mode
+            input_copyright = input("# Input Copyright to write in the copyright missing files (ex, 'Copyright <year> <name>'') : ")
+            if input_copyright == 'Quit' or input_copyright == 'quit' or input_copyright == 'Q':
+                return
+
+            input_ok = check_input_format(input_copyright)
+            if input_ok is False:
+                return
+
+        if input_copyright != "":
+            logger.warning(f"  * Your input Copyright : {input_copyright}")
+            parsed_args = main_parser.parse_args(['addheader', '--copyright',
+                                                  'SPDX-FileCopyrightText: ' + str(input_copyright),
+                                                  '--exclude-year'] + missing_copyright_list)
+            try:
+                run(parsed_args, project)
+            except Exception as ex:
+                print_error('Error_call_run_in_copyright :' + str(ex))
+
+
+def get_allfiles_list(path):
+    all_files = []
+
+    try:
+        for root, dirs, files in os.walk(path):
+            for file in files:
+                file_lower_case = file.lower()
+                file_abs_path = os.path.join(root, file_lower_case)
+                file_rel_path = os.path.relpath(file_abs_path, path)
+                all_files.append(file_rel_path)
+    except Exception as ex:
+        print_error('Error_Get_AllFiles : ' + str(ex))
+
+    return all_files
+
+
+def save_result_log():
+    try:
+        _str_final_result_log = safe_dump(_result_log, allow_unicode=True, sort_keys=True)
+        logger.info(_str_final_result_log)
+    except Exception as ex:
+        logger.warning("Failed to print add result log. " + str(ex))
+
+
+def add_content(path_to_find, file, manual_mode, input_license="", input_copyright=""):
+    global _auto_add_mode, _result_log
+    file_to_check_list = []
+    _auto_add_mode = False
+    _check_only_file_mode = False
+
+    if path_to_find == "":
+        path_to_find = os.getcwd()
+
+    now = datetime.now().strftime('%Y%m%d_%H-%M-%S')
+    output_dir = os.getcwd()
+    logger, _result_log = init_log(os.path.join(output_dir, "fosslight_reuse_add_log_"+now+".txt"),
+                                   True, logging.INFO, logging.DEBUG, _PKG_NAME, path_to_find)
+
+    if input_copyright != "" and manual_mode is False:
+        input_ok = check_input_format(input_copyright)
+        if input_ok is False:
+            return
+
+    if file != "":
+        file_to_check_list = file.split(',')
+        _check_only_file_mode = True
+
+    if not manual_mode and _check_only_file_mode is False:
+        if input_license == "" and input_copyright == "":
+            logger.info(" You have to input license and copyright to add with -l and -c option")
+            return
+        _auto_add_mode = True
+
+    if _check_only_file_mode:
+        main_parser = reuse_arg_parser()
+
+        missing_license_list, missing_copyright_list, error_occurred, project = reuse_for_files(path_to_find, file_to_check_list)
+
+        if missing_license_list is not None and len(missing_license_list) > 0:
+            logger.warning(f"  * Your input license : {input_license}")
+            parsed_args = main_parser.parse_args(['addheader', '--license', str(input_license)] + missing_license_list)
+            try:
+                run(parsed_args, project)
+            except Exception as ex:
+                print_error('Error_call_run_in_license_file_only :' + str(ex))
+
+        if missing_copyright_list is not None and len(missing_copyright_list) > 0:
+            logger.warning(f"  * Your input Copyright : {input_copyright}")
+            parsed_args = main_parser.parse_args(['addheader', '--copyright',
+                                                  'SPDX-FileCopyrightText: ' + str(input_copyright),
+                                                  '--exclude-year'] + missing_copyright_list)
+            try:
+                run(parsed_args, project)
+            except Exception as ex:
+                print_error('Error_call_run_in_copyright_file_only :' + str(ex))
+    else:
+        # Get all files List in path
+        all_files_list = get_allfiles_list(path_to_find)
+
+        str_lint_result, missing_license, missing_copyright, oss_pkg_info, error_occurred, project = reuse_for_project(path_to_find)
+
+        # Print Skipped Files
+        missing_license_filtered, missing_copyright_filtered = \
+            check_license_and_copyright(path_to_find, all_files_list, missing_license, missing_copyright)
+
+        # Set missing license and copyright
+        set_missing_license_copyright(missing_license_filtered,
+                                      missing_copyright_filtered,
+                                      project,
+                                      path_to_find,
+                                      input_license,
+                                      input_copyright)
+
+    save_result_log()

--- a/src/fosslight_reuse/_fosslight_reuse.py
+++ b/src/fosslight_reuse/_fosslight_reuse.py
@@ -17,6 +17,7 @@ from reuse import report
 from reuse.project import Project
 from reuse.report import ProjectReport
 
+
 _PKG_NAME = "fosslight_reuse"
 _RULE_LINK = "https://oss.lge.com/guide/process/osc_process/1-identification/copyright_license_rule.html"
 _MSG_REFERENCE = "Ref. Copyright and License Writing Rules in Source Code. : " + _RULE_LINK
@@ -40,15 +41,15 @@ def find_oss_pkg_info(path):
                            "requirements.txt", "package.json", "pom.xml",
                            "build.gradle",
                            "podfile.lock", "cartfile.resolved"]
-
     oss_pkg_info = []
+
     try:
         for root, dirs, files in os.walk(path):
             for file in files:
                 file_lower_case = file.lower()
-
                 file_abs_path = os.path.join(root, file)
                 file_rel_path = os.path.relpath(file_abs_path, path)
+
                 if file_lower_case in _OSS_PKG_INFO_FILES or file_lower_case.startswith("module_license_"):
                     oss_pkg_info.append(file_rel_path)
                 elif is_binary(file_abs_path):
@@ -119,6 +120,7 @@ def reuse_for_files(path, files):
     global _DEFAULT_EXCLUDE_EXTENSION_FILES
 
     missing_license_list = []
+    missing_copyright_list = []
     error_occurred = False
 
     try:
@@ -142,6 +144,8 @@ def reuse_for_files(path, files):
 
                         if rep.spdxfile.licenses_in_file is None or len(rep.spdxfile.licenses_in_file) == 0:
                             missing_license_list.append(file)
+                        if rep.spdxfile.copyright is None or len(rep.spdxfile.copyright) == 0:
+                            missing_copyright_list.append(file)
 
             except Exception as ex:
                 print_error('Error_Reuse_for_file_to_read :' + str(ex))
@@ -150,12 +154,13 @@ def reuse_for_files(path, files):
         print_error('Error_Reuse_for_file :' + str(ex))
         error_occurred = True
 
-    return missing_license_list, error_occurred
+    return missing_license_list, missing_copyright_list, error_occurred, prj
 
 
 def reuse_for_project(repository):
     result = ""
     missing_license = []
+    missing_copyright = []
     error_occured = False
 
     oss_pkg_info_files = find_oss_pkg_info(repository)
@@ -192,13 +197,19 @@ def reuse_for_project(repository):
             repository += "/"
         missing_license = [sub.replace(repository, '') for sub in missing_license]
 
+        # File list that missing copyright text
+        missing_copyright = [str(sub) for sub in set(report.files_without_copyright)]
+        if not repository.endswith("/"):
+            repository += "/"
+        missing_copyright = [sub.replace(repository, '') for sub in missing_copyright]
+
     except Exception as ex:
         print_error('Error_Reuse_lint:' + str(ex))
         error_occured = True
 
     if _turn_on_default_reuse_config:
         remove_reuse_dep5_file(need_rollback, temp_file_name, temp_dir_name)
-    return result, missing_license, oss_pkg_info_files, error_occured
+    return result, missing_license, missing_copyright, oss_pkg_info_files, error_occured, project
 
 
 def print_error(error_msg: str):
@@ -237,7 +248,7 @@ def result_for_summary(str_lint_result, oss_pkg_info, path, msg_missing_files):
     logger.info(msg_missing_files + str_summary)
 
 
-def result_for_missing_license_files(files_without_license, oss_pkg_info):
+def result_for_missing_license_and_copyright_files(files_without_license, copyright_without_files, oss_pkg_info):
     global _root_xml_item
     message = ""
     # If the oss_pkg_file exists,
@@ -248,6 +259,7 @@ def result_for_missing_license_files(files_without_license, oss_pkg_info):
         print_mode = True
 
     str_missing_lic_files = ""
+    str_missing_cop_files = ""
     for file_name in files_without_license:
         items = ET.Element('error')
         items.set('file', file_name)
@@ -258,13 +270,26 @@ def result_for_missing_license_files(files_without_license, oss_pkg_info):
             _root_xml_item.append(items)
         str_missing_lic_files += ("* " + file_name + "\n")
 
+    for file_name in copyright_without_files:
+        items = ET.Element('error')
+        items.set('file', file_name)
+        items.set('id', 'rule_key_osc_checker_02')
+        items.set('line', '0')
+        items.set('msg', _MSG_FOLLOW_LIC_TXT)
+        if _check_only_file_mode:
+            _root_xml_item.append(items)
+        str_missing_cop_files += ("* " + file_name + "\n")
+
     if _check_only_file_mode and _DEFAULT_EXCLUDE_EXTENSION_FILES is not None and len(
             _DEFAULT_EXCLUDE_EXTENSION_FILES) > 0:
         logger.info("# FILES EXCLUDED - NOT SUBJECT TO REUSE")
         logger.info('* %s' % '\n* '.join(map(str, _DEFAULT_EXCLUDE_EXTENSION_FILES)))
         logger.info("\n" + _MSG_REFERENCE)
-    elif print_mode and files_without_license is not None and len(files_without_license) > 0:
-        message = "# MISSING LICENSES FROM FILE LIST TO CHECK\n" + str_missing_lic_files + "\n"
+    else:
+        if print_mode and files_without_license is not None and len(files_without_license) > 0:
+            message = "# MISSING LICENSES FROM FILE LIST TO CHECK\n" + str_missing_lic_files + "\n"
+        if print_mode and copyright_without_files is not None and len(copyright_without_files) > 0:
+            message += "# MISSING COPYRIGHT FROM FILE LIST TO CHECK\n" + str_missing_cop_files + "\n"
 
     return message
 
@@ -328,16 +353,20 @@ def run_lint(path_to_find, file, disable, result_file):
         init(path_to_find, result_file, file_to_check_list)
 
     if _check_only_file_mode:
-        license_missing_files, error_occurred = reuse_for_files(path_to_find, file_to_check_list)
+        license_missing_files, copyright_missing_files, error_occurred, project = reuse_for_files(path_to_find, file_to_check_list)
         oss_pkg_info = []
     else:
-        str_lint_result, license_missing_files, oss_pkg_info, error_occurred = reuse_for_project(path_to_find)
+        str_lint_result, license_missing_files, copyright_missing_files, oss_pkg_info, error_occurred, project \
+            = reuse_for_project(path_to_find)
 
     if error_occurred:  # In case reuse lint failed
         _exit_code = os.EX_SOFTWARE
     else:
-        msg_missing_files = result_for_missing_license_files(license_missing_files, oss_pkg_info)
+        msg_missing_files = result_for_missing_license_and_copyright_files(license_missing_files, copyright_missing_files, oss_pkg_info)
         if not _check_only_file_mode:
-            result_for_summary(str_lint_result, oss_pkg_info, path_to_find, msg_missing_files)
+            result_for_summary(str_lint_result,
+                               oss_pkg_info,
+                               path_to_find,
+                               msg_missing_files)
 
     write_xml_and_exit(result_file, _exit_code)

--- a/src/fosslight_reuse/_help.py
+++ b/src/fosslight_reuse/_help.py
@@ -7,6 +7,7 @@ from fosslight_util.help import PrintHelpMsg
 _HELP_MESSAGE_REUSE = """
     Usage: fosslight_reuse [Mode] [option1] <arg1> [option2] <arg2>...
         ex) fosslight_reuse lint -p /home/test/ -f "notice/sample.py,src/init.py"
+            fosslight_reuse add -c "Copyright 2019-2021 LG Electronics Inc." -l "GPL-3.0"
 
     FOSSLight Reuse is a Tool to check REUSE compliance in source code.
 
@@ -14,13 +15,18 @@ _HELP_MESSAGE_REUSE = """
         Mode
             lint\t\t    Check REUSE compliance
             report\t\t    oss_pkg_info.yaml <-> FOSSLight-Report.xml
+            add\t\t\t    Add missing license and copyright
 
         Options:
             -h\t\t\t    Print help message
             -p <path>\t\t    Path to check
             -f <file1,file2,..>\t    List of files to check
             -o <file_name>\t    Output file name
-            -n\t\t\t    Don't exclude venv*, node_modules, and .*/ from the analysis """
+            -n\t\t\t    Don't exclude venv*, node_modules, and .*/ from the analysis
+        Options for only 'add' mode
+            -l <license>\t    License name(SPDX format) to add
+            -c <copyright>\t    Copyright to add(ex, "Copyright 2015-2021 LGE Electronics")
+            -m\t\t\t    Add manually your input license and copyright (using without -l or -c option)  """
 
 
 def print_help_msg(exitOpt=True):

--- a/src/fosslight_reuse/cli.py
+++ b/src/fosslight_reuse/cli.py
@@ -6,21 +6,27 @@ import argparse
 from ._help import _HELP_MESSAGE_REUSE
 from ._fosslight_reuse import run_lint
 from fosslight_oss_pkg.fosslight_oss_pkg import convert_report
+from ._add import add_content
 
 
 def main():
     parser = argparse.ArgumentParser(description='FOSSLight Reuse', usage=_HELP_MESSAGE_REUSE)
-    parser.add_argument('mode', help='lint | report')
+    parser.add_argument('mode', help='lint | report | add')
     parser.add_argument('--path', '-p', help='Path to check', type=str, dest='path', default="")
     parser.add_argument('--file', '-f', help='Files to check', type=str, dest='file', default="")
     parser.add_argument('--output', '-o', help='Output file name', type=str, dest='output', default="")
     parser.add_argument('--no', '-n', help='Disable automatic exclude mode', action='store_true', dest='disable')
+    parser.add_argument('--manual', '-m', help='Manual input mode', action='store_true', dest='manual')
+    parser.add_argument('--license', '-l', help='License name to add', type=str, dest='license', default="")
+    parser.add_argument('--copyright', '-c', help='Copyright to add', type=str, dest='copyright', default="")
     args = parser.parse_args()
 
     if args.mode == "lint":
         run_lint(args.path, args.file, args.disable, args.output)
     elif args.mode == "report":
         convert_report(args.path, args.file, args.output)
+    elif args.mode == "add":
+        add_content(args.path, args.file, args.manual, args.license, args.copyright)
     else:
         pass
 

--- a/tests/add/test_add.py
+++ b/tests/add/test_add.py
@@ -1,0 +1,13 @@
+
+import os
+from fosslight_util.set_log import init_log
+
+
+def main():
+    output_dir = "tests"
+    logger, _result_log = init_log(os.path.join(output_dir, "test_add_log.txt"))
+    logger.warning("TESTING - add mode")
+
+
+if __name__ == '__main__':
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ skipdist = true
 install_command = pip install {opts} {packages}
 basepython= python3.6
 whitelist_externals = cat
+                      cp
+                      rm
 setenv =
   PYTHONPATH=.
 
@@ -25,7 +27,9 @@ commands =
     fosslight_reuse report -p tests/report
     fosslight_reuse report -f tests/report/OSS-Report-Sample_1_BOM.xlsx -o test_report/output
     cat test_report/output.yaml
-
+    rm -rf tests/add_result
+    cp -r tests/add tests/add_result
+    fosslight_reuse add -p tests/add_result -c "Copyright 2019-2021 LG Electronics Inc." -l "GPL-3.0"
 [testenv:release]
 deps =
     -r{toxinidir}/requirements-dev.txt
@@ -36,4 +40,6 @@ commands =
     fosslight_reuse lint -p src/ -f "fosslight_reuse/wrapper_reuse_lint.py" -o "test_result2/reuse_result.xml"
     fosslight_reuse report -p tests/report
     fosslight_reuse report -f tests/report/OSS-Report-Sample_1_BOM.xlsx -o test_report/output
+    cp -r tests/add tests/add_result
+    fosslight_reuse add -p tests/add_result -c "Copyright 2019-2021 LG Electronics Inc." -l "GPL-3.0"
     pytest -v --flake8


### PR DESCRIPTION
## Description
- Print file lists that have both license and copyright
- Add license / copyright at the header of missing license / copyright file
- Add manual and automatic mode to add copyright / license


## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

