### PR TITLE
Add excution error result

### DIFF
--- a/src/fosslight_reuse/_fosslight_reuse.py
+++ b/src/fosslight_reuse/_fosslight_reuse.py
@@ -16,7 +16,7 @@ from fosslight_util.parsing_yaml import parsing_yml, find_all_oss_pkg_files
 from reuse import report
 from reuse.project import Project
 from reuse.report import ProjectReport
-from fosslight_reuse._result import write_result_file, create_result_file, result_for_summary
+from fosslight_reuse._result import write_result_file, create_result_file, result_for_summary, ResultItem
 
 PKG_NAME = "fosslight_reuse"
 REUSE_CONFIG_FILE = ".reuse/dep5"
@@ -287,6 +287,7 @@ def run_lint(target_path, format, disable, output_file_name):
     _exit_code = os.EX_OK
     path_to_find = ""
     report = ProjectReport()
+    result_item = ResultItem()
     success = False
 
     try:
@@ -317,9 +318,10 @@ def run_lint(target_path, format, disable, output_file_name):
                                          report,
                                          _result_log,
                                          _check_only_file_mode,
-                                         file_to_check_list)
+                                         file_to_check_list,
+                                         error_items)
 
-    success, exit_code = write_result_file(result_file, format, _exit_code, result_item, _result_log, error_items)
+    success, exit_code = write_result_file(result_file, format, _exit_code, result_item, _result_log)
     if success:
         logger.info(f"\nCreated file name: {result_file}\n")
     else:


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
- Add excution error result
- Bug fix about output file name when using -o option


< Example of xml >
```
<?xml version='1.0' encoding='UTF-8'?>
<results><error id="rule_key_osc_checker_01" line="0" msg="&#10;# SUMMARY&#10;* Open Source Package File: &#10;                                * Detected Licenses : -, GPL-3.0-only&#10;                                * Files without copyright : 5 / 16&#10;                                * Files without license : 5 / 16&#10;&#10;&#10;Ref. Copyright and License Writing Rules in Source Code. : https://oss.lge.com/guide/process/osc_process/1-identification/copyright_license_rule.html" /><execution_errors><execution_error>Can't find oss-pkg-info file</execution_error><execution_error>Can't find a path</execution_error></execution_errors></results>
```

< Example of yaml >
```
Checking copyright/license writing rules:
  Compliant: Not OK
  Summary:
    Open Source Package File: []
    Detected Licenses:
    - '-'
    - GPL-3.0-only
    Count without license / Total: 5 / 16
    Count without copyright / Total: 5 / 16
  Files without license and copyright:
  - fosslight_reuse.egg-info/SOURCES.txt
  - fosslight_reuse.egg-info/dependency_links.txt
  - fosslight_reuse.egg-info/entry_points.txt
  - fosslight_reuse.egg-info/requires.txt
  - fosslight_reuse.egg-info/top_level.txt
  Files without license:
  - fosslight_reuse.egg-info/SOURCES.txt
  - fosslight_reuse.egg-info/dependency_links.txt
  - fosslight_reuse.egg-info/entry_points.txt
  - fosslight_reuse.egg-info/requires.txt
  - fosslight_reuse.egg-info/top_level.txt
  Files without copyright:
  - fosslight_reuse.egg-info/SOURCES.txt
  - fosslight_reuse.egg-info/dependency_links.txt
  - fosslight_reuse.egg-info/entry_points.txt
  - fosslight_reuse.egg-info/requires.txt
  - fosslight_reuse.egg-info/top_level.txt
  Tool Info:
    OS Info: Linux 4.15.0-144-generic
    Path to analyze: /home/jaekwonbang/fosslight_reuse_0512/src
    Python Version: 3
    FL Reuse Version: fosslight_reuse v2.1.9
  Excution Error:
  - Can't make result file
  - Can't find oss pakage file
```

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

