### PR TITLE
Fix the bug that Excel cannot be created if there is only one row in Convert mode

### DIFF
--- a/src/fosslight_oss_pkg/_parsing_excel.py
+++ b/src/fosslight_oss_pkg/_parsing_excel.py
@@ -47,7 +47,7 @@ def convert_yml_to_excel(oss_pkg_files, output_file, file_option_on, base_path, 
             logger.warning(f"Output: {output_file}_SRC_FL_Reuse.csv")
         except Exception as ex:
             logger.error(f"Write .xlsx file : {ex}")
-    if len(items_to_print) > 1:
+    if items_to_print and len(items_to_print) > 0:
         try:
             sheet_list["SRC_FL_Reuse"] = items_to_print
             write_result_to_excel(f"{output_file}.xlsx", sheet_list)

--- a/src/fosslight_reuse/_fosslight_reuse.py
+++ b/src/fosslight_reuse/_fosslight_reuse.py
@@ -170,7 +170,7 @@ def get_excluded_path_in_yaml(repository, yaml_files):
         for oss_item in oss_items:
             if oss_item.exclude:
                 for source_name_or_path in oss_item.source_name_or_path:
-                    yield os.path.join(oss_item.relative_path, source_name_or_path}
+                    yield os.path.join(oss_item.relative_path, source_name_or_path)
 
 
 def get_only_pkg_info_yaml_file(pkg_info_files):


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Fix the bug that Excel cannot be created if there is only one row in Convert mode.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

