### PR TITLE
Make the sheet to convert selectable. (-s sheet name option)

### DIFF
--- a/src/fosslight_oss_pkg/fosslight_oss_pkg.py
+++ b/src/fosslight_oss_pkg/fosslight_oss_pkg.py
@@ -39,7 +39,7 @@ def find_report_file(path_to_find):
     return ""
 
 
-def convert_report(base_path, output_name, need_log_file=True):
+def convert_report(base_path, output_name, need_log_file=True, sheet_names=""):
     oss_pkg_files = ["oss-pkg-info.yml", "oss-pkg-info.yaml"]
     file_option_on = False
     convert_yml_mode = False
@@ -74,7 +74,7 @@ def convert_report(base_path, output_name, need_log_file=True):
 
     if os.path.isdir(base_path):
         if output_extension == ".yaml":
-            logger.error(f"Format error - can make only .xlsx file")
+            logger.error("Format error - can make only .xlsx file")
             sys.exit(1)
         convert_yml_mode = True
     else:
@@ -101,7 +101,7 @@ def convert_report(base_path, output_name, need_log_file=True):
         convert_yml_to_excel(oss_pkg_files, output_report, file_option_on, base_path, is_window)
 
     if convert_excel_mode:
-        convert_excel_to_yaml(report_to_read, output_yaml)
+        convert_excel_to_yaml(report_to_read, output_yaml, sheet_names)
 
     try:
         _str_final_result_log = safe_dump(_result_log, allow_unicode=True, sort_keys=True)

--- a/src/fosslight_reuse/_help.py
+++ b/src/fosslight_reuse/_help.py
@@ -27,7 +27,10 @@ _HELP_MESSAGE_REUSE = """
 
         Options for only 'add' mode
             -l <license>\t    License name(SPDX format) to add
-            -c <copyright>\t    Copyright to add(ex, 2015-2021 LG Electronics Inc.)"""
+            -c <copyright>\t    Copyright to add(ex, 2015-2021 LG Electronics Inc.)
+
+        Options for only 'convert' mode
+            -s <sheet_names>\t    Sheet name in excel to change to yaml(ex. SRC,BIN)"""
 
 
 def print_help_msg(exitOpt=True):

--- a/src/fosslight_reuse/cli.py
+++ b/src/fosslight_reuse/cli.py
@@ -18,6 +18,7 @@ def main():
     parser.add_argument('--no', '-n', help='Disable automatic exclude mode', action='store_true', dest='disable')
     parser.add_argument('--license', '-l', help='License name to add', type=str, dest='license', default="")
     parser.add_argument('--copyright', '-c', help='Copyright to add', type=str, dest='copyright', default="")
+    parser.add_argument('--sheet', '-s', help='Sheet name to change to yaml', type=str, dest='sheet', default="")
     parser.add_argument('--help', '-h', help='Print help message', action='store_true', dest='help')
     parser.add_argument('--ignore', '-i', help='Do not write log to file', action='store_false', dest='log')
     try:
@@ -31,7 +32,7 @@ def main():
     if args.mode == "lint":
         run_lint(args.path, args.disable, args.output, args.format, args.log)
     elif args.mode == "convert":
-        convert_report(args.path, args.output, args.log)
+        convert_report(args.path, args.output, args.log, args.sheet)
     elif args.mode == "add":
         add_content(args.path, args.license, args.copyright, args.output, args.log)
     else:


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
### In convert mode, make it possible to select the sheet to be converted in Excel.
- Multiple sheet names can be entered with the -s option. (ex. SRC, BIN)
- If user does not enter the -s option, convert all sheets starting with SRC, BIN, and BOM.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

