### PR TITLE
Find sheet names without case sensitivity

### DIFF
--- a/src/fosslight_oss_pkg/_parsing_excel.py
+++ b/src/fosslight_oss_pkg/_parsing_excel.py
@@ -83,7 +83,7 @@ def write_yaml_file(output_file, json_output):
 def read_oss_report(excel_file, sheet_names=""):
     _oss_report_items = []
     _xl_sheets = []
-    SHEET_PREFIX_TO_READ = ["BIN", "BOM", "SRC"]
+    SHEET_PREFIX_TO_READ = ["bin", "bom", "src"]
     if sheet_names:
         sheet_name_prefix_math = False
         sheet_name_to_read = sheet_names.split(",")
@@ -96,8 +96,9 @@ def read_oss_report(excel_file, sheet_names=""):
         xl_workbook = xlrd.open_workbook(excel_file)
         for sheet_name in xl_workbook.sheet_names():
             try:
-                if any(((sheet_name_prefix_math and sheet_name.startswith(sheet_to_read))
-                       or sheet_name == sheet_to_read)
+                sheet_name_lower = sheet_name.lower()
+                if any(((sheet_name_prefix_math and sheet_name_lower.startswith(sheet_to_read.lower()))
+                       or sheet_name_lower == sheet_to_read.lower())
                        for sheet_to_read in sheet_name_to_read):
                     sheet = xl_workbook.sheet_by_name(sheet_name)
                     if sheet:


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
In convert mode, when receiving an input for the sheet name to be converted to -s, search without case-sensitive.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

