### PR TITLE
Apply fnmatch / re match to match file name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ reuse
 PyYAML
 xlrd==1.2.0
 XlsxWriter==1.2.9
-fosslight_util>=1.4.0
+fosslight_util>=1.4.2

--- a/src/fosslight_reuse/_add.py
+++ b/src/fosslight_reuse/_add.py
@@ -419,7 +419,7 @@ def add_content(target_path="", input_license="", input_copyright="", output_pat
         all_files_list = get_allfiles_list(path_to_find)
 
         # Get missing license / copyright file list
-        missing_license, missing_copyright, _, project, _, _, _, _ = reuse_for_project(path_to_find, need_log_file)
+        missing_license, missing_copyright, _, project, _ = reuse_for_project(path_to_find, need_log_file)
 
         # Print Skipped Files
         missing_license_filtered, missing_copyright_filtered = \

--- a/src/fosslight_reuse/_constant.py
+++ b/src/fosslight_reuse/_constant.py
@@ -19,23 +19,24 @@ HTML_FORMAT_PREFIX = """
         <style>
             .marker{background-color: Yellow;}
             .underline{text-decoration-line: underline;}
+            table{width: 100%;}
         </style>
         <title>FOSSLight Reuse</title>
     </head>
     <body>
-        <table cellspacing="0" cellpadding="0" border="0" style="font-family:'arial,sans-serif'">
-            <tr>
-                <td>
-                    <table cellspacing="0" cellpadding="0" border="0">
-                        <tr>
-                            <td colspan="3" height="25" style="background:#c00c3f">
-                                <h1 style="margin:0;padding-left:5px;font-size:14px;color:white">FOSSLight Reuse Lint</h1>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td width="1" style="background:#ddd"></td>
-                            <td style="padding:40px;">
-                                <div style="padding-bottom:10px;font-size:16px;font-weight:bold;">"""
+            <table cellspacing="0" cellpadding="0" border="0" style="font-family:'arial,sans-serif'">
+                <tr>
+                    <td>
+                        <table cellspacing="0" cellpadding="0" border="0">
+                            <tr>
+                                <td colspan="3" height="25" style="background:#c00c3f">
+                                    <h1 style="margin:0;padding-left:5px;font-size:14px;color:white">FOSSLight Reuse Lint</h1>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td width="1" style="background:#ddd"></td>
+                                <td style="padding:40px;">
+                                    <div style="padding-bottom:10px;font-size:16px;font-weight:bold;">"""
 
 HTML_COMPLIANCE_SUFFIX = "</div>"
 HTML_CELL_HEAD_ROW = """<h2 style="margin:20px 0 0;padding:10px;font-size:16px;">« Files without License or Copyright »</h2>"""
@@ -48,22 +49,18 @@ HTML_CELL_PREFIX = """
                                     </tr>"""
 
 HTML_FORMAT_SUFFIX = """
-                                </table>
-                                <br/>
-                             </td>
-                            <td width="1" style="background:#ddd"></td>
-                        </tr>
-                        <tr>
-                            <td colspan="3" height="1" style="background:#ddd"></td>
-                        </tr>
-                    </table>
-                </td>
-                <td width="60" style="background:#f9f9f9"></td>
-            </tr>
-            <tr>
-                <td colspan="3" height="28" style="background:#f9f9f9"></td>
-            </tr>
-        </table>
+                                    </table>
+                                    <br/>
+                                </td>
+                                <td width="1" style="background:#ddd"></td>
+                            </tr>
+                            <tr>
+                                <td colspan="3" height="1" style="background:#ddd"></td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
     </body>
 </html>
 """

--- a/src/fosslight_reuse/_constant.py
+++ b/src/fosslight_reuse/_constant.py
@@ -5,9 +5,9 @@
 
 DEFAULT_EXCLUDE_EXTENSION = ["jar", "png", "exe", "so", "a", "dll", "jpeg", "jpg", "ttf", "lib", "ttc", "pfb",
                              "pfm", "otf", "afm", "dfont", "json"]
-OSS_PKG_INFO_FILES = ["oss-pkg-info.yaml", "oss-pkg-info.yml", r"oss-package*.info", "requirement.txt",
+OSS_PKG_INFO_FILES = [r"oss-pkg-info[\s\S]*.yaml", "oss-pkg-info.yml", r"oss-package[\s\S]*.info", "requirement.txt",
                       "requirements.txt", "package.json", "pom.xml", "build.gradle", "podfile.lock", "cartfile.resolved",
-                      "pubspec.yaml", "package.resolved", "go.mod", r"fosslight-sbom-info*.yaml"]
+                      "pubspec.yaml", "package.resolved", "go.mod", r"fosslight-sbom-info[\s\S]*.yaml"]
 HTML_RESULT_EXPAND_LIMIT = 10
 HTML_RESULT_PRINT_LIMIT = 100
 

--- a/src/fosslight_reuse/_result.py
+++ b/src/fosslight_reuse/_result.py
@@ -15,6 +15,7 @@ from reuse.project import Project
 from fosslight_reuse._result_html import result_for_html
 from fosslight_util.parsing_yaml import find_all_oss_pkg_files, parsing_yml
 from fosslight_util.output_format import check_output_format
+import re
 
 
 CUSTOMIZED_FORMAT_FOR_REUSE = {'html': '.html', 'xml': '.xml', 'yaml': '.yaml'}
@@ -237,7 +238,7 @@ def extract_files_in_path(remove_file_list, base_file_list, return_found=False):
 
     for remove_pattern in remained_file_to_remove:
         for file in remained_base_files[:]:
-            if fnmatch.fnmatch(file, remove_pattern):
+            if fnmatch.fnmatch(file, remove_pattern) or re.search(remove_pattern, file):
                 extract_files.append(file)
                 remained_base_files.remove(file)
     return extract_files if return_found else remained_base_files

--- a/src/fosslight_reuse/_result.py
+++ b/src/fosslight_reuse/_result.py
@@ -288,12 +288,10 @@ def result_for_summary(path_to_find, oss_pkg_info_files, license_missing_files, 
     if oss_pkg_info_files:
         pkg_info_yaml_files = find_all_oss_pkg_files(path_to_find, oss_pkg_info_files)
         yaml_file = get_only_pkg_info_yaml_file(pkg_info_yaml_files)
-        # Remove OSS Package files from missing files
-        pkg_info_yaml_files = [os.path.relpath(pkg_file, path_to_find) for pkg_file in pkg_info_yaml_files]
         # Exclude files in yaml
         license_missing_files, copyright_missing_files = exclude_file_in_yaml(path_to_find, yaml_file,
-                                                                              set(license_missing_files) - set(pkg_info_yaml_files),
-                                                                              set(copyright_missing_files) - set(pkg_info_yaml_files))
+                                                                              set(license_missing_files) - set(oss_pkg_info_files),
+                                                                              set(copyright_missing_files) - set(oss_pkg_info_files))
 
     if len(license_missing_files) == 0 and len(copyright_missing_files) == 0:
         reuse_compliant = True

--- a/src/fosslight_reuse/_result.py
+++ b/src/fosslight_reuse/_result.py
@@ -217,8 +217,11 @@ def create_result_file(output_file_name, format='', _start_time=""):
 
 def get_only_pkg_info_yaml_file(pkg_info_files):
     for yaml_file in pkg_info_files:
-        if os.path.basename(yaml_file) == "oss-pkg-info.yaml":
-            yield yaml_file
+        try:
+            if re.search(r"oss-pkg-info[\s\S]*.yaml", os.path.basename(yaml_file).lower()):
+                yield yaml_file
+        except Exception as ex:
+            logger.debug(f"Error to find oss-pkg-info*.yaml: {ex}")
 
 
 def get_path_in_yaml(oss_item):


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
- Changed logic to find and remove files excluded from yaml
  - AS-IS: Find list of files to exclude from yaml in files without license/copyright and remove them later.
  - TO-BE: If you find a file to be excluded from yaml in a file without license/copyright, remove it immediately.
- OSS Package file is excluded from the list of files without license/copyright
- The name of the yaml file to parse:
  - AS-IS: oss-pkg-info.yaml
  - TO-BE: oss-pkg-info*.yaml
- How to match against files written to yaml:
  - AS-IS: File name pattern match using fnmath
  - TO-BE: Match the file name pattern using fnmath, and if it does not match, match regular expression
Reason: When only the folder name is written (ex. In case of temp, to match all temp/*)
- Fixed bug where oss-pkg-info*.yaml file could not be found in OSS Package file list

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

